### PR TITLE
[Bug Fix] Global Shortcut fix for MacOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Go to the [Releases Page](https://github.com/GameGodS3/DropPoint/releases) to do
 - Drag and drop any file(s) or folder from the system into DropPoint, go to your desired location and drag it out.
 
 - App minimises to tray by default when you close the instance. To open instance, click on system tray. To quit, right click on tray icon > Quit.
-- While DropPoint is in the system tray, pressing <kbd>Shift</kbd> + <kbd>Caps Lock</kbd> anywhere in your PC would toggle an instance of DropPoint. (as tested on Windows)
+- While DropPoint is in the system tray, pressing <kbd>Shift</kbd> + <kbd>Caps Lock</kbd> anywhere in your PC would toggle an instance of DropPoint. (as tested on Windows and Linux) (the shortcut is <kbd>Shift</kbd> + <kbd>Tab</kbd> on MacOs)
 
 ## :gear: Developer Installation
 

--- a/src/Shortcut.js
+++ b/src/Shortcut.js
@@ -6,13 +6,22 @@ const { createMainWindow } = require("./Window");
  */
 const setShortcut = () => {
   let visible = true;
-  const ret = globalShortcut.register("Shift+Capslock", () => {
+
+  let shortcut = "Shift+Capslock";
+
+  if (process.platform === "darwin") {
+    shortcut = "Shift+Tab"
+  }
+
+  const ret = globalShortcut.register(shortcut, () => {
     if (DROPPOINT_MAIN) {
       DROPPOINT_MAIN.close();
     } else {
       createMainWindow();
     }
   });
+
+
 
   if (!ret) {
     console.log("KeyboardShorcutError");


### PR DESCRIPTION
## Context

- The existing shortcut <kbd>Shift</kbd> + <kbd>Caps Lock</kbd> works on Windows and Linux, but not on MacOs because <kbd>Caps Lock</kbd> is considered a modifier key on the MacOs platform but not on Windows and Linux. 
- Keyboard Shortcuts need to be of the form Modifier Key/Keys + Final Key on any platform.

## Changes Made

- Switched to <kbd>Shift</kbd> + <kbd>Tab</kbd> as a shortcut specifically for MacOs keeping the Windows and Linux shortcuts unchanged.
- Updated Readme to mention the MacOs shortcut.