### PR TITLE
[Bug Fix]: Fix remove window buttons on MacOs

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -72,6 +72,10 @@ function createMainWindow(debug = false) {
 
   DROPPOINT_MAIN.loadFile(path.join(__dirname, "../static/index.html"));
   DROPPOINT_MAIN.setVisibleOnAllWorkspaces(true);
+
+  // on MacOs setting frame: false is not enough to remove title bar buttons, need to setWindowButtonVisibility
+  DROPPOINT_MAIN.setWindowButtonVisibility(false);
+
   DROPPOINT_MAIN.shadow = true;
   DROPPOINT_MAIN.removeMenu();
 


### PR DESCRIPTION
### Context

<!--

Provide context for your PR.

- If you are FIXING A BUG, link the Issue where the bug is mentioned. 
  If there are no such Issues already, create one. Bug fixes without linking the issue may be closed.
- If you have ADDED A FEATURE, make a very short one-line description of it here. Long description is required in next section anyway.
- If it's a DOCUMENTATION IMPROVEMENT, skip this section (and remove it).
- 

-->

On MacOs just setting ```frame: false``` didn't seem to remove the OS's native title bar window buttons like in Windows and Linux.
<img width="312" alt="2021-10-09_22 32 32" src="https://user-images.githubusercontent.com/55079486/136667661-ddfc193b-1d1a-438f-868a-cb49cfe7192d.png">



### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR adds a small change and adds  ```setWindowButtonVisibility(false);``` parameter which seems to fix the issue on MacOs.

### Possible Drawbacks

<!-- Optional-->
<!-- What are the possible side-effects or negative impacts of the code change? -->

This change has not been tested on Windows and Linux.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Tested on MacOs and Confirmed the change fixes the issue.

<img width="312" alt="Screenshot 2021-10-09 at 10 35 18 PM" src="https://user-images.githubusercontent.com/55079486/136667759-77203cce-0d35-4b88-b75b-411f22323fb3.png">


### Release Notes

Fixed an Issue where the OS native Window buttons persisted on MacOs.

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in DropPoint's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple files couldn't be dragged in.
- Increased the performance of responding to keyboard shortcuts.

-->

