### PR TITLE
Add token permissions for build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,13 @@
 name: Build
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_on_linux:
+    permissions:
+      contents: write  # for samuelmeuli/action-electron-builder to create a release
     runs-on: ubuntu-latest
     steps:
     - name: Check out Git repository
@@ -29,6 +34,8 @@ jobs:
         release: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
   build_on_mac:
+    permissions:
+      contents: write  # for samuelmeuli/action-electron-builder to create a release
     runs-on: macos-latest
     steps:
     - name: Check out Git repository
@@ -51,6 +58,8 @@ jobs:
         release: ${{ startsWith(github.ref, 'refs/tags/v') }}
       
   build_on_win:
+    permissions:
+      contents: write  # for samuelmeuli/action-electron-builder to create a release
     runs-on: windows-latest
     steps:
     - name: Check out Git repository


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

StepSecurity is working on securing GitHub workflows and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using StepSecurity's secure-workflows online tool [app.stepsecurity.io](https://github.com/cosmos/cosmos-sdk/pull/app.stepsecurity.io) to improve the security of GitHub workflows.

We have fixed one of the repo's workflows for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity online tool at [app.stepsecurity.io](https://app.stepsecurity.io/).