### PR TITLE
Fix: error when Cmd Q quitting on mac

### DIFF
--- a/src/Shortcut.js
+++ b/src/Shortcut.js
@@ -1,4 +1,4 @@
-const { globalShortcut } = require("electron");
+const { globalShortcut, app } = require("electron");
 const { Instance } = require("./Window");
 
 /**
@@ -8,7 +8,13 @@ const setShortcut = () => {
   let shortcut = "Shift+Capslock";
 
   if (process.platform === "darwin") {
+    //caps lock is not a modifier in mac
     shortcut = "Shift+Tab";
+
+    //handle macos cmd q quitting
+    globalShortcut.register("Cmd+Q", () => {
+      app.exit();
+    })
   }
 
   const ret = globalShortcut.register(shortcut, () => {


### PR DESCRIPTION
This PR fixes the above issue by adding a globalshortcut for Cmd+Q to execute electron's app.quit()