### PR TITLE
[Bug Fix]: Support for Shelf over Fullscreen apps on MacOs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "droppoint",
   "productName": "DropPoint",
-  "version": "1.2.0",
+  "version": "1.2.0-1",
   "description": "Drag-and-drop assist",
   "main": "./src/App.js",
   "scripts": {
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "electron": "^13.1.2",
-    "electron-builder": "^22.11.7"
+    "electron-builder": "^23.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "droppoint",
   "productName": "DropPoint",
-  "version": "1.2.0-1",
+  "version": "1.2.1",
   "description": "Drag-and-drop assist",
   "main": "./src/App.js",
   "scripts": {
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "electron": "^13.1.2",
-    "electron-builder": "^23.0.2"
+    "electron-builder": "^22.11.1"
   }
 }

--- a/src/Window.js
+++ b/src/Window.js
@@ -55,7 +55,7 @@ class Instance {
 
     this.instance.loadURL(`file://${html_path}?id=${this.id}`);
 
-    this.instance.setVisibleOnAllWorkspaces(true);
+    this.instance.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
     if (this.devFlag) this.instance.webContents.openDevTools();
 


### PR DESCRIPTION
### Context
Fixes #27 and #30 

### Description of the Change
- Adds a simple property ```{ visibleOnFullScreen: true }``` to ```setVisibleOnAllWorkspaces```
- Change version of ```electron-builder``` to ```22.11.1``` as it was causing issues building for M1 machines.

